### PR TITLE
전체 페이지 타입 지정

### DIFF
--- a/api/httpClient.ts
+++ b/api/httpClient.ts
@@ -10,7 +10,7 @@ export const apiClient = axios.create({
   },
 });
 
-export const popularListApi = (type: string) => {
+export const popularListApiRequests = (type: string) => {
   const commonQuery =
     "language=ko&watch_region=KR&sort_by=popularity.desc&vote_average.gte=0&vote_average.lte=10&vote_count.gte=0&with_runtime.gte=0&with_runtime.lte=400&page=1";
   const movieCommonQuery = `discover/movie?include_adult=false&include_video=false&${commonQuery}`;
@@ -41,17 +41,23 @@ export const popularListApi = (type: string) => {
       break;
   }
 
+  return requests;
+};
+
+export const popularListApi = (type: string) => {
+  const requests = popularListApiRequests(type);
+
   return Promise.all(requests)
     .then((res) => res)
     .catch((error) => {
-      console.error(error);
+      throw error;
     });
 };
 
 export const mainApi = () => {
   const requests = [
     apiClient.get("trending/all/day?language=ko"),
-    popularListApi("stream"),
+    ...popularListApiRequests("stream"),
     apiClient.get(
       `discover/movie?include_adult=false&include_video=false&language=ko&watch_region=KR&sort_by=popularity.desc&with_watch_monetization_types=free|ads&with_genres=&vote_average.gte=0&vote_average.lte=10&vote_count.gte=0&with_runtime.gte=0&with_runtime.lte=400&page=1`
     ),
@@ -60,7 +66,7 @@ export const mainApi = () => {
   return Promise.all(requests)
     .then((res) => res)
     .catch((error) => {
-      console.error(error);
+      throw error;
     });
 };
 
@@ -77,7 +83,7 @@ export const contentDetailApi = (id: string | null, type: string | null) => {
   return Promise.all(requests)
     .then((res) => res)
     .catch((error) => {
-      console.error(error);
+      throw error;
     });
 };
 
@@ -112,7 +118,7 @@ export const searchResultsApi = (value: string | null) => {
       );
     })
     .catch((error) => {
-      console.error(error);
+      throw error;
     });
 };
 
@@ -184,6 +190,6 @@ export const personDetailApi = (personId: string | null) => {
       return { koData, biography, famous, acting };
     })
     .catch((error) => {
-      console.error(error);
+      throw error;
     });
 };

--- a/api/httpClient.ts
+++ b/api/httpClient.ts
@@ -1,4 +1,3 @@
-import { PersonDetailDataType } from "@/app/personDetail/page";
 import axios from "axios";
 
 export const apiClient = axios.create({
@@ -137,7 +136,7 @@ export const personDetailApi = (personId: string | null) => {
       const { cast } = koData.data.combined_credits;
       const sortCopy = [...cast];
       const releaseCopy = [...cast];
-      const expected: any = [];
+      const expected: PersonDetailDataType[] = [];
       let currentYear = "";
       let famous = [];
       let acting = [];
@@ -152,24 +151,30 @@ export const personDetailApi = (personId: string | null) => {
         famous = famous.slice(0, 8);
       }
 
-      const releasefilter: any = releaseCopy.filter((val: any) => {
-        if (!val.first_air_date && !val.release_date) {
-          expected.push(val);
+      const releasefilter: PersonDetailDataType[] = releaseCopy.filter(
+        (val: PersonDetailDataType) => {
+          if (!val.first_air_date && !val.release_date) {
+            expected.push(val);
+          }
+
+          return val.first_air_date || val.release_date;
         }
+      );
 
-        return val.first_air_date || val.release_date;
-      });
+      const releaseSort = releasefilter.sort(
+        (val1: PersonDetailDataType, val2: PersonDetailDataType) => {
+          console.log(val1);
 
-      const releaseSort = releasefilter.sort((val1: any, val2: any) => {
-        const date1 = val1.first_air_date || val1.release_date;
-        const date2 = val2.first_air_date || val2.release_date;
+          const date1 = val1.first_air_date || val1.release_date || "";
+          const date2 = val2.first_air_date || val2.release_date || "";
 
-        if (date1 > date2) return -1;
-        else if (date1 < date2) return 1;
-        else 0;
-      });
+          if (date1 > date2) return -1;
+          else if (date1 < date2) return 1;
+          else return 0;
+        }
+      );
 
-      acting = releaseSort.map((val: any, idx: number) => {
+      acting = releaseSort.map((val: PersonDetailDataType, idx: number) => {
         const date = val.first_air_date || val.release_date;
         const checkDate = !date ? "" : date.slice(0, 4);
         if (idx !== 0 && currentYear !== checkDate) {
@@ -185,7 +190,7 @@ export const personDetailApi = (personId: string | null) => {
       }
 
       const split = enData.data.biography.split("\n");
-      const biography = split.filter((val: any) => val);
+      const biography = split.filter((val: string) => val);
 
       return { koData, biography, famous, acting };
     })

--- a/api/httpClient.ts
+++ b/api/httpClient.ts
@@ -163,8 +163,6 @@ export const personDetailApi = (personId: string | null) => {
 
       const releaseSort = releasefilter.sort(
         (val1: PersonDetailDataType, val2: PersonDetailDataType) => {
-          console.log(val1);
-
           const date1 = val1.first_air_date || val1.release_date || "";
           const date2 = val2.first_air_date || val2.release_date || "";
 

--- a/app/contentDetail/page.tsx
+++ b/app/contentDetail/page.tsx
@@ -16,18 +16,20 @@ export default function ContentDetailPage() {
   const { isLoading, setIsLoading } = useContext(GlobalContext);
   const params = useSearchParams();
   const [isTypeTV, setIsTypeTV] = useState<boolean>(false);
-  const [detailData, setDetailData] = useState<any>({
-    backdrop_path: "",
-    poster_path: "",
-    genres: [],
-    created_by: [],
+  const [movieInfolData, setMovieInfolData] = useState<MovieInfoType>(() => {
+    return {} as MovieInfoType;
   });
-  const [keywordData, setKeywordData] = useState<any>({
-    keywords: [],
-    results: [{ id: -1, name: "" }],
+  const [tvInfolData, setTvInfolData] = useState<TVShowInfoType>(() => {
+    return {} as TVShowInfoType;
   });
-  const [castData, setCastData] = useState<any>([]);
-  const [date, setDate] = useState<any>({
+
+  const [keywordData, setKeywordData] = useState<KeywordType[]>([]);
+  const [castData, setCastData] = useState<CastInfoType[]>([]);
+  const [date, setDate] = useState<{
+    year: string;
+    month: string;
+    day: string;
+  }>({
     year: "",
     month: "",
     day: "",
@@ -40,18 +42,18 @@ export default function ContentDetailPage() {
 
     setIsTypeTV(contentType === "tv");
 
-    contentDetailApi(contentId, contentType).then((res: any) => {
+    contentDetailApi(contentId, contentType).then((res) => {
       const [contents, credits, keywords] = res;
       const contentDate =
-        contentType === "tv"
-          ? contents.data.first_air_date
-          : contents.data.release_date;
+        contents.data.first_air_date || contents.data.release_date;
+
       const dateSplit = contentDate.split("-");
       const slice = credits.data.cast.slice(0, 9);
 
-      setDetailData(contents.data);
+      if (contentType === "tv") setTvInfolData(contents.data);
+      else setMovieInfolData(contents.data);
       setCastData(slice);
-      setKeywordData(keywords.data);
+      setKeywordData(keywords.data.keywords || keywords.data.results);
 
       setDate({
         ...date,
@@ -66,12 +68,18 @@ export default function ContentDetailPage() {
   return (
     !isLoading && (
       <>
-        <TopInfo isTypeTV={isTypeTV} detailData={detailData} date={date} />
+        <TopInfo
+          isTypeTV={isTypeTV}
+          movieInfolData={movieInfolData}
+          tvInfolData={tvInfolData}
+          date={date}
+        />
         <div className={contentsDetailStyles.detail_info}>
           <MainCast isTypeTV={isTypeTV} castData={castData} />
           <SideInfo
             isTypeTV={isTypeTV}
-            detailData={detailData}
+            movieInfolData={movieInfolData}
+            tvInfolData={tvInfolData}
             keywordData={keywordData}
           />
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,14 +13,24 @@ import homeStyles from "@styles/pages/home/home.module.scss";
 
 export default function Home() {
   const { isLoading, setIsLoading } = useContext(GlobalContext);
-  const [listData, setListData] = useState<any>([]);
+
+  const [trendingData, setTrendingData] = useState<ContentsDataType[]>([]);
+  const [popularData, setPopularData] = useState<ContentsDataType[]>([]);
+  const [freeWatchData, setFreeWatchData] = useState<ContentsDataType[]>([]);
 
   useEffect(() => {
     setIsLoading(true);
-    mainApi().then((res: any) => {
-      const resData = [res[0].data.results, res[1], res[2].data.results];
+    mainApi().then((res) => {
+      const movieData = res[1].data.results;
+      const tvData = res[2].data.results;
+      const popularConcat = movieData.concat(tvData);
 
-      setListData(resData);
+      setTrendingData(res[0].data.results);
+      setPopularData(popularConcat);
+      setFreeWatchData(res[2].data.results);
+
+      console.log(res);
+
       setIsLoading(false);
     });
   }, []);
@@ -29,9 +39,9 @@ export default function Home() {
     !isLoading && (
       <div className={homeStyles.home}>
         <SearchBar />
-        <TrendingList list={listData[0]} />
-        <PopularList list={listData[1]} />
-        <FreeWatchList list={listData[2]} />
+        <TrendingList list={trendingData} />
+        <PopularList list={popularData} />
+        <FreeWatchList list={freeWatchData} />
       </div>
     )
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -29,8 +29,6 @@ export default function Home() {
       setPopularData(popularConcat);
       setFreeWatchData(res[2].data.results);
 
-      console.log(res);
-
       setIsLoading(false);
     });
   }, []);

--- a/app/person/page.tsx
+++ b/app/person/page.tsx
@@ -12,18 +12,6 @@ import CustomImage from "@/components/common/customImage";
 
 import personStyles from "@styles/pages/person/person.module.scss";
 
-export type PersonDataType = {
-  adult: boolean;
-  gender: number;
-  id: number;
-  known_for: PersonDetailDataType[];
-  known_for_department?: string;
-  name?: string;
-  original_name?: string;
-  popularity?: number;
-  profile_path?: string;
-};
-
 export default function PersonPage() {
   const { isLoading, setIsLoading } = useContext(GlobalContext);
   const [personData, setPersonData] = useState<PersonDataType[]>([]);

--- a/app/person/page.tsx
+++ b/app/person/page.tsx
@@ -7,7 +7,6 @@ import { GlobalContext } from "../context";
 import { apiClient } from "@/api/httpClient";
 
 import { Pagination } from "@mui/material";
-import { PersonDetailDataType } from "../personDetail/page";
 import CustomImage from "@/components/common/customImage";
 
 import personStyles from "@styles/pages/person/person.module.scss";

--- a/app/personDetail/page.tsx
+++ b/app/personDetail/page.tsx
@@ -13,47 +13,36 @@ import Career from "@/components/pages/personDetail/career";
 
 import personDetailStyles from "@styles/pages/personDetail/personDetail.module.scss";
 
-export type PersonDetailDataType = {
-  adult: boolean;
-  backdrop_path?: string;
-  character?: string;
-  credit_id?: string;
-  episode_count?: number;
-  first_air_date?: string;
-  genre_ids: number[];
-  id: number;
-  media_type?: string;
-  title?: string;
-  name?: string;
-  origin_country: string[];
-  original_language?: string;
-  original_name?: string;
-  overview?: string;
-  popularity?: number;
-  poster_path?: string;
-  vote_average?: number;
-  vote_count: number;
-};
-
 export default function PersonDetailPage() {
-  const { isLoading, setIsLoading } = useContext(GlobalContext);
-  const [personDetailData, setPersonDetailData] = useState<any>({
-    profile_path: "",
-    also_known_as: [],
-    birthday: "",
-  });
-  const [biography, setBiography] = useState<any>([]);
-  const [famousData, setFamousData] = useState<any>([]);
-  const [acting, setActing] = useState<any>([]);
-
   const params = useSearchParams();
-  const gender = ["-", "여성", "남성"];
+  const { isLoading, setIsLoading } = useContext(GlobalContext);
+
+  const [biography, setBiography] = useState<string[]>([]);
+  const [famousData, setFamousData] = useState<PersonDetailDataType[]>([]);
+  const [acting, setActing] = useState<PersonDetailDataType[]>([]);
+  const [personInfoData, setPersonInfoData] = useState<personInfoType>({
+    adult: false,
+    also_known_as: [],
+    biography: "",
+    birthday: "",
+    combined_credits: { cast: [], crew: [] },
+    deathday: null,
+    gender: 0,
+    homepage: null,
+    id: 0,
+    imdb_id: "",
+    known_for_department: "",
+    name: "",
+    place_of_birth: "",
+    popularity: 230.142,
+    profile_path: "",
+  });
 
   useEffect(() => {
     const personId = params.get("id");
     setIsLoading(true);
-    personDetailApi(personId).then((res: any) => {
-      setPersonDetailData(res.koData.data);
+    personDetailApi(personId).then((res) => {
+      setPersonInfoData(res.koData.data);
       setBiography(res.biography);
       setFamousData(res.famous);
       setActing(res.acting);
@@ -64,21 +53,14 @@ export default function PersonDetailPage() {
   return (
     !isLoading && (
       <div className={personDetailStyles.person_detail}>
-        <SideInfo
-          gender={gender}
-          acting={acting}
-          personDetailData={personDetailData}
-        />
+        <SideInfo acting={acting} personInfoData={personInfoData} />
         <div className={personDetailStyles.detail_info}>
           <div className={personDetailStyles.person_name}>
-            {personDetailData.name}
+            {personInfoData.name}
           </div>
           <div>
             <div className={personDetailStyles.info_title}>약력</div>
-            <History
-              biography={biography}
-              personDetailData={personDetailData}
-            />
+            <History biography={biography} personInfoData={personInfoData} />
           </div>
           <div>
             <div className={personDetailStyles.info_title}>유명 작품</div>

--- a/app/searchResults/layout.tsx
+++ b/app/searchResults/layout.tsx
@@ -11,28 +11,6 @@ import SearchIcon from "@mui/icons-material/Search";
 
 import searchResultsStyles from "@styles/pages/searchResults/searchResults.module.scss";
 
-type ConnetType = {
-  [index: string]: string;
-  tv: string;
-  movie: string;
-  person: string;
-  collection: string;
-  company: string;
-  keyword: string;
-};
-
-type SearchResultsDataType = {
-  page: number;
-  results: [];
-  total_pages: number;
-  total_results: number;
-};
-
-type SearchResultsResType = {
-  data: SearchResultsDataType;
-  type: string;
-};
-
 export default function SearchResultsPage({
   children,
 }: {
@@ -74,7 +52,7 @@ export default function SearchResultsPage({
 
   useEffect(() => {
     setIsLoading(true);
-    searchResultsApi(searchVal).then((res: any) => {
+    searchResultsApi(searchVal).then((res) => {
       setSearchData(res);
       setIsLoading(false);
     });

--- a/app/searchResults/movieSearch/page.tsx
+++ b/app/searchResults/movieSearch/page.tsx
@@ -7,7 +7,6 @@ import { apiClient } from "@/api/httpClient";
 
 import { Pagination } from "@mui/material";
 import SearchResultsList from "@/components/pages/searchResults/searchResultsList";
-import { ContentDataType } from "@/components/pages/contents/contents";
 
 import searchResultsStyles from "@styles/pages/searchResults/searchResults.module.scss";
 
@@ -15,7 +14,7 @@ export default function MovieSearchPage() {
   const params = useSearchParams();
   const searchVal = params.get("search");
   const query = `query=${searchVal}&include_adult=false&language=ko&page=`;
-  const [searchData, setSearchData] = useState<ContentDataType[]>([]);
+  const [searchData, setSearchData] = useState<ContentsDataType[]>([]);
 
   const [totalPages, setTotalPages] = useState<number>(1);
   const [currentPage, setCurrentPage] = useState<number>(1);

--- a/app/searchResults/page.tsx
+++ b/app/searchResults/page.tsx
@@ -10,7 +10,7 @@ export default function SearchResultsPage() {
   const router = useRouter();
 
   useEffect(() => {
-    searchResultsApi(searchVal).then((res: any) => {
+    searchResultsApi(searchVal).then((res) => {
       router.replace(`/searchResults/${res[0].type}Search?search=${searchVal}`);
     });
   }, []);

--- a/app/searchResults/personSearch/page.tsx
+++ b/app/searchResults/personSearch/page.tsx
@@ -14,7 +14,7 @@ export default function PersonSearchPage() {
   const params = useSearchParams();
   const searchVal = params.get("search");
   const query = `query=${searchVal}&include_adult=false&language=ko&page=`;
-  const [searchData, setSearchData] = useState<ContentsDataType[]>([]);
+  const [searchData, setSearchData] = useState<PersonDataType[]>([]);
 
   const [totalPages, setTotalPages] = useState<number>(1);
   const [currentPage, setCurrentPage] = useState<number>(1);

--- a/app/searchResults/personSearch/page.tsx
+++ b/app/searchResults/personSearch/page.tsx
@@ -7,7 +7,6 @@ import { apiClient } from "@/api/httpClient";
 
 import PersonList from "../../../components/pages/searchResults/personList";
 import { Pagination } from "@mui/material";
-import { PersonDataType } from "@/app/person/page";
 
 import searchResultsStyles from "@styles/pages/searchResults/searchResults.module.scss";
 
@@ -15,7 +14,7 @@ export default function PersonSearchPage() {
   const params = useSearchParams();
   const searchVal = params.get("search");
   const query = `query=${searchVal}&include_adult=false&language=ko&page=`;
-  const [searchData, setSearchData] = useState<PersonDataType[]>([]);
+  const [searchData, setSearchData] = useState<ContentsDataType[]>([]);
 
   const [totalPages, setTotalPages] = useState<number>(1);
   const [currentPage, setCurrentPage] = useState<number>(1);

--- a/app/searchResults/tvSearch/page.tsx
+++ b/app/searchResults/tvSearch/page.tsx
@@ -7,7 +7,6 @@ import { apiClient } from "@/api/httpClient";
 
 import { Pagination } from "@mui/material";
 import SearchResultsList from "../../../components/pages/searchResults/searchResultsList";
-import { ContentDataType } from "@/components/pages/contents/contents";
 
 import searchResultsStyles from "@styles/pages/searchResults/searchResults.module.scss";
 
@@ -15,7 +14,7 @@ export default function TVSearchPage() {
   const params = useSearchParams();
   const searchVal = params.get("search");
   const query = `query=${searchVal}&include_adult=false&language=ko&page=`;
-  const [searchData, setSearchData] = useState<ContentDataType[]>([]);
+  const [searchData, setSearchData] = useState<ContentsDataType[]>([]);
 
   const [totalPages, setTotalPages] = useState<number>(1);
   const [currentPage, setCurrentPage] = useState<number>(1);

--- a/components/common/customCheckbox.tsx
+++ b/components/common/customCheckbox.tsx
@@ -1,7 +1,14 @@
 import Image from "next/image";
 import customCheckBox from "@styles/common/customCheckbox.module.scss";
 
-export default function CustomCheckbox({ id, text, ...props }: any) {
+export default function CustomCheckbox({
+  id,
+  text,
+  ...props
+}: {
+  id: string;
+  text?: string;
+}) {
   return (
     <label className={customCheckBox.custom_checkbox} htmlFor={id}>
       <input

--- a/components/common/customCheckbox.tsx
+++ b/components/common/customCheckbox.tsx
@@ -1,26 +1,33 @@
+import { HTMLProps, forwardRef } from "react";
 import Image from "next/image";
 import customCheckBox from "@styles/common/customCheckbox.module.scss";
 
-export default function CustomCheckbox({
-  id,
-  text,
-  ...props
-}: {
+interface CustomCheckboxProps extends HTMLProps<HTMLInputElement> {
   id: string;
   text?: string;
-}) {
-  return (
-    <label className={customCheckBox.custom_checkbox} htmlFor={id}>
-      <input
-        type="checkbox"
-        id={id}
-        className={customCheckBox.input}
-        {...props}
-      />
-      <span className={customCheckBox.checkbox_icon}>
-        <Image src="/images/checkImg.png" fill sizes="1x" alt="check" />
-      </span>
-      <span className={customCheckBox.checkbox_text}>{text}</span>
-    </label>
-  );
 }
+
+const CustomCheckbox = forwardRef<HTMLInputElement, CustomCheckboxProps>(
+  ({ id, text, ...props }, ref) => {
+    return (
+      <label className={customCheckBox.custom_checkbox} htmlFor={id}>
+        <input
+          ref={ref}
+          type="checkbox"
+          id={id}
+          value=""
+          className={customCheckBox.input}
+          {...props}
+        />
+        <span className={customCheckBox.checkbox_icon}>
+          <Image src="/images/checkImg.png" fill sizes="1x" alt="check" />
+        </span>
+        <span className={customCheckBox.checkbox_text}>{text}</span>
+      </label>
+    );
+  }
+);
+
+CustomCheckbox.displayName = "CustomCheckbox";
+
+export default CustomCheckbox;

--- a/components/common/customImage.tsx
+++ b/components/common/customImage.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Image from "next/image";
 
 import customImage from "@styles/common/customImage.module.scss";
@@ -30,7 +30,11 @@ export default function CustomImage({
     setIsError(true);
   };
 
-  const imageRef = useRef<any>(null);
+  const imageRef = useRef<HTMLImageElement>(null);
+
+  useEffect(() => {
+    setImagePath(src);
+  }, [src]);
 
   return (
     <div

--- a/components/common/customSlider.tsx
+++ b/components/common/customSlider.tsx
@@ -1,17 +1,15 @@
-import { useEffect, useState } from "react";
+import { forwardRef, useEffect, useState } from "react";
 import Slider from "@mui/material/Slider";
 import customSliderStyles from "@styles/common/customSlider.module.scss";
 
-export default function CustomSlider({
-  max,
-  step,
-  pointNum,
-  ...props
-}: {
-  max: number;
-  step: number;
-  pointNum: number;
-}) {
+const CustomSlider = forwardRef<
+  HTMLDivElement,
+  {
+    max: number;
+    step: number;
+    pointNum: number;
+  }
+>(({ max, step, pointNum, ...props }, ref) => {
   const [graduationArr, setGraduationArr] = useState<number[]>([]);
 
   useEffect(() => {
@@ -42,6 +40,7 @@ export default function CustomSlider({
         })}
       </div>
       <Slider
+        ref={ref}
         min={0}
         max={max}
         step={step}
@@ -50,4 +49,8 @@ export default function CustomSlider({
       />
     </div>
   );
-}
+});
+
+CustomSlider.displayName = "CustomSlider";
+
+export default CustomSlider;

--- a/components/pages/contents/contents.tsx
+++ b/components/pages/contents/contents.tsx
@@ -11,70 +11,6 @@ import ContentsList from "./contentsList";
 
 import contentsStyles from "@styles/pages/contents/contents.module.scss";
 
-export type GenreDataType = {
-  id: number;
-  name: string;
-  checked?: boolean;
-};
-
-export type ReleaseDateType = {
-  [index: string]: boolean;
-  all_releases: boolean;
-  theater_limited: boolean;
-  theater: boolean;
-  premier: boolean;
-  digital: boolean;
-  physical_media: boolean;
-  tv: boolean;
-};
-
-export type AirDateType = {
-  [index: string]: boolean;
-  all_episodes: true;
-  first_air_date: true;
-};
-
-export type AvailabilitiesType = {
-  [index: string]: boolean;
-  all_availabilities: boolean;
-  stream: boolean;
-  free: boolean;
-  ads: boolean;
-  rent: boolean;
-  buy: boolean;
-};
-
-export type DiscoverDataType = {
-  sort_by: string;
-  availabilities: AvailabilitiesType;
-  release: ReleaseDateType | AirDateType;
-  release_date_g: Date | null;
-  release_date_l: Date | null;
-  genre: GenreDataType[];
-  vote_average: number[];
-  vote_count: 0;
-  runtime: number[];
-};
-
-export type ContentDataType = {
-  adult: boolean;
-  backdrop_path?: string;
-  genre_ids: number[];
-  id: number;
-  original_language?: string;
-  original_title?: string;
-  overview?: string;
-  popularity?: number;
-  poster_path?: string;
-  release_date?: string;
-  first_air_date?: string;
-  title?: string;
-  name?: string;
-  video: boolean;
-  vote_average?: number;
-  vote_count?: number;
-};
-
 export default function Contents({ contentType }: { contentType: string }) {
   const { isLoading, setIsLoading } = useContext(GlobalContext);
   const currentDate = new Date();
@@ -84,7 +20,7 @@ export default function Contents({ contentType }: { contentType: string }) {
   const [pageCount, setPageCount] = useState<number>(1);
 
   const [totalPage, setTotalPage] = useState<number>(0);
-  const [listData, setListData] = useState<ContentDataType[]>([]);
+  const [listData, setListData] = useState<ContentsDataType[]>([]);
   const [isReload, setIsReload] = useState<boolean>(false);
   const [currentQuery, setCurrentQuery] = useState<string>(
     `${contentType}/popular?language=ko&page=`

--- a/components/pages/contents/contentsList.tsx
+++ b/components/pages/contents/contentsList.tsx
@@ -1,5 +1,4 @@
 import { dateFormatter } from "@/utils/dateFormatter";
-import { ContentDataType } from "./contents";
 import Link from "next/link";
 import CustomImage from "@/components/common/customImage";
 
@@ -12,15 +11,15 @@ export default function ContentsList({
   totalPage,
   onClickAddList,
 }: {
-  listData: ContentDataType[];
+  listData: ContentsDataType[];
   contentType: string;
   totalPage: number;
-  onClickAddList: any;
+  onClickAddList: () => void;
 }) {
   return (
     <div className={contentsListStyles.contents_list}>
       <ul>
-        {listData.map((val: ContentDataType) => {
+        {listData.map((val: ContentsDataType) => {
           const { id, poster_path, vote_average } = val;
 
           const title = contentType === "movie" ? val.title : val.name;

--- a/components/pages/contents/filterBar/filterBar.tsx
+++ b/components/pages/contents/filterBar/filterBar.tsx
@@ -3,7 +3,6 @@
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 
-import { DiscoverDataType } from "@/components/pages/contents/contents";
 import FilterBarCard from "./filterBarCard";
 import Availabilities from "./filterBarItems/availabilities";
 import ReleaseDates from "./filterBarItems/releaseDates";

--- a/components/pages/contents/filterBar/filterBarItems/availabilities.tsx
+++ b/components/pages/contents/filterBar/filterBarItems/availabilities.tsx
@@ -1,7 +1,6 @@
 import { Control, Controller, useWatch } from "react-hook-form";
 
 import CustomCheckbox from "@/components/common/customCheckbox";
-import { DiscoverDataType } from "@/components/pages/contents/contents";
 
 import filterBarCardStyles from "@styles/pages/contents/filterBar/filterBarCard.module.scss";
 import availabilitiesStyles from "@styles/pages/contents/filterBar/filterItems/availabilities.module.scss";

--- a/components/pages/contents/filterBar/filterBarItems/availabilities.tsx
+++ b/components/pages/contents/filterBar/filterBarItems/availabilities.tsx
@@ -27,7 +27,7 @@ export default function Availabilities({
               id="all_availabilities"
               text="Search all availabilities?"
               checked={field.value}
-              {...field}
+              onChange={field.onChange}
             />
           )}
         />
@@ -41,7 +41,7 @@ export default function Availabilities({
                   id="Stream"
                   text="Stream"
                   checked={field.value}
-                  {...field}
+                  onChange={field.onChange}
                 />
               )}
             />
@@ -53,7 +53,7 @@ export default function Availabilities({
                   id="free"
                   text="Free"
                   checked={field.value}
-                  {...field}
+                  onChange={field.onChange}
                 />
               )}
             />
@@ -65,7 +65,7 @@ export default function Availabilities({
                   id="Ads"
                   text="Ads"
                   checked={field.value}
-                  {...field}
+                  onChange={field.onChange}
                 />
               )}
             />
@@ -77,7 +77,7 @@ export default function Availabilities({
                   id="Rent"
                   text="Rent"
                   checked={field.value}
-                  {...field}
+                  onChange={field.onChange}
                 />
               )}
             />
@@ -89,7 +89,7 @@ export default function Availabilities({
                   id="buy"
                   text="Buy"
                   checked={field.value}
-                  {...field}
+                  onChange={field.onChange}
                 />
               )}
             />

--- a/components/pages/contents/filterBar/filterBarItems/genre.tsx
+++ b/components/pages/contents/filterBar/filterBarItems/genre.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from "react";
 import CategoryButtons from "@/components/pages/contents/filterBar/filterBarItems/genreButtons";
 import { apiClient } from "@/api/httpClient";
 import { FieldValues, SetFieldValue } from "react-hook-form";
-import { GenreDataType } from "@/components/pages/contents/contents";
 
 import filterBarCardStyles from "@styles/pages/contents/filterBar/filterBarCard.module.scss";
 

--- a/components/pages/contents/filterBar/filterBarItems/releaseDatePicker.tsx
+++ b/components/pages/contents/filterBar/filterBarItems/releaseDatePicker.tsx
@@ -3,7 +3,6 @@ import ReactDatePicker from "react-datepicker";
 import EventIcon from "@mui/icons-material/Event";
 
 import "react-datepicker/dist/react-datepicker.css";
-import { DiscoverDataType } from "@/components/pages/contents/contents";
 
 import releaseDatesStyles from "@styles/pages/contents/filterBar/filterItems/releaseDates.module.scss";
 

--- a/components/pages/contents/filterBar/filterBarItems/releaseDates.tsx
+++ b/components/pages/contents/filterBar/filterBarItems/releaseDates.tsx
@@ -3,7 +3,6 @@ import { Control, Controller, useWatch } from "react-hook-form";
 import ReleaseDatePicker from "./releaseDatePicker";
 
 import CustomCheckbox from "@/components/common/customCheckbox";
-import { DiscoverDataType } from "@/components/pages/contents/contents";
 
 import filterBarCardStyles from "@styles/pages/contents/filterBar/filterBarCard.module.scss";
 import releaseDatesStyles from "@styles/pages/contents/filterBar/filterItems/releaseDates.module.scss";
@@ -11,7 +10,7 @@ import releaseDatesStyles from "@styles/pages/contents/filterBar/filterItems/rel
 export default function ReleaseDates({
   control,
 }: {
-  control: Control<DiscoverDataType, any>;
+  control: Control<DiscoverDataType>;
 }) {
   const pathname = usePathname();
 

--- a/components/pages/contents/filterBar/filterBarItems/releaseDates.tsx
+++ b/components/pages/contents/filterBar/filterBarItems/releaseDates.tsx
@@ -20,9 +20,9 @@ export default function ReleaseDates({
 
   return (
     <div className={filterBarCardStyles.card_item}>
-      <div>{pathname === "/tv" ? "방영일자" : "Release Dates"}</div>
+      <div>{pathname === "/contents/tv" ? "방영일자" : "Release Dates"}</div>
 
-      {pathname === "/tv" ? (
+      {pathname === "/contents/tv" ? (
         <div>
           <Controller
             name="release.all_episodes"
@@ -32,7 +32,7 @@ export default function ReleaseDates({
                 id="all_episodes"
                 text="Search all episodes?"
                 checked={field.value}
-                {...field}
+                onChange={field.onChange}
               />
             )}
           />
@@ -46,7 +46,7 @@ export default function ReleaseDates({
                     id="first_air_date"
                     text="Search first air date?"
                     checked={field.value}
-                    {...field}
+                    onChange={field.onChange}
                   />
                 )}
               />
@@ -63,7 +63,7 @@ export default function ReleaseDates({
                 id="all_releases"
                 text="Search all releases?"
                 checked={field.value}
-                {...field}
+                onChange={field.onChange}
               />
             )}
           />
@@ -77,7 +77,7 @@ export default function ReleaseDates({
                       id="allCountries"
                       text="Search all countries?"
                       checked={field.value}
-                      {...field}
+                      onChange={field.onChange}
                     />
                   )}
                 />
@@ -90,7 +90,7 @@ export default function ReleaseDates({
                     id="theater_limited"
                     text="극장 (제한)"
                     checked={field.value}
-                    {...field}
+                    onChange={field.onChange}
                   />
                 )}
               />
@@ -102,7 +102,7 @@ export default function ReleaseDates({
                     id="theater"
                     text="극장"
                     checked={field.value}
-                    {...field}
+                    onChange={field.onChange}
                   />
                 )}
               />
@@ -114,7 +114,7 @@ export default function ReleaseDates({
                     id="premier"
                     text="프리미어"
                     checked={field.value}
-                    {...field}
+                    onChange={field.onChange}
                   />
                 )}
               />
@@ -126,7 +126,7 @@ export default function ReleaseDates({
                     id="digital"
                     text="디지털"
                     checked={field.value}
-                    {...field}
+                    onChange={field.onChange}
                   />
                 )}
               />
@@ -138,7 +138,7 @@ export default function ReleaseDates({
                     id="physical_media"
                     text="물리매체"
                     checked={field.value}
-                    {...field}
+                    onChange={field.onChange}
                   />
                 )}
               />
@@ -150,7 +150,7 @@ export default function ReleaseDates({
                     id="releaseTv"
                     text="TV"
                     checked={field.value}
-                    {...field}
+                    onChange={field.onChange}
                   />
                 )}
               />

--- a/components/pages/contents/filterBar/filterBarItems/sliderFilter.tsx
+++ b/components/pages/contents/filterBar/filterBarItems/sliderFilter.tsx
@@ -1,9 +1,13 @@
-import { Controller } from "react-hook-form";
+import { Control, Controller } from "react-hook-form";
 
 import CustomSlider from "@/components/common/customSlider";
 import filterBarCardStyles from "@styles/pages/contents/filterBar/filterBarCard.module.scss";
 
-export default function SliderFilter({ control }: { control: any }) {
+export default function SliderFilter({
+  control,
+}: {
+  control: Control<DiscoverDataType>;
+}) {
   return (
     <>
       <div className={filterBarCardStyles.card_item}>

--- a/components/pages/contents/filterBar/filterBarItems/sort.tsx
+++ b/components/pages/contents/filterBar/filterBarItems/sort.tsx
@@ -1,8 +1,12 @@
-import { Controller } from "react-hook-form";
+import { Control, Controller } from "react-hook-form";
 
 import filterBarCardStyles from "@styles/pages/contents/filterBar/filterBarCard.module.scss";
 
-export default function Sort({ control }: any) {
+export default function Sort({
+  control,
+}: {
+  control: Control<DiscoverDataType>;
+}) {
   return (
     <div className={filterBarCardStyles.card_item}>
       <div>Sort Results By</div>

--- a/components/pages/contentsDetail/mainCast.tsx
+++ b/components/pages/contentsDetail/mainCast.tsx
@@ -3,13 +3,19 @@ import Link from "next/link";
 
 import mainCastStyles from "@styles/pages/contentsDetail/mainCast.module.scss";
 
-export default function MainCast({ isTypeTV, castData }: any) {
+export default function MainCast({
+  isTypeTV,
+  castData,
+}: {
+  isTypeTV: boolean;
+  castData: CastInfoType[];
+}) {
   return (
     <div>
       <div className={mainCastStyles.title}>주요 출연진</div>
       <div className={mainCastStyles.cast_list}>
         <ul>
-          {castData.map((val: any) => {
+          {castData.map((val: CastInfoType) => {
             const { id, name, roles, profile_path, character } = val;
             return (
               <li key={id}>
@@ -25,7 +31,7 @@ export default function MainCast({ isTypeTV, castData }: any) {
                     <Link href={`/personDetail?id=${id}`}>{name}</Link>
                   </div>
                   <div className={mainCastStyles.casting}>
-                    {isTypeTV ? roles[0].character : character}
+                    {isTypeTV && roles ? roles[0].character : character}
                   </div>
                 </div>
               </li>

--- a/components/pages/contentsDetail/sideInfo.tsx
+++ b/components/pages/contentsDetail/sideInfo.tsx
@@ -1,6 +1,21 @@
 import sideInfoStyles from "@styles/pages/contentsDetail/sideInfo.module.scss";
+import { useEffect, useState } from "react";
 
-export default function SideInfo({ isTypeTV, detailData, keywordData }: any) {
+export default function SideInfo({
+  isTypeTV,
+  movieInfolData,
+  tvInfolData,
+  keywordData,
+}: {
+  isTypeTV: boolean;
+  movieInfolData: MovieInfoType;
+  tvInfolData: TVShowInfoType;
+  keywordData: KeywordType[];
+}) {
+  const [contentsData, setContentsData] = useState<
+    MovieInfoType | TVShowInfoType
+  >(movieInfolData || tvInfolData);
+
   const dollarFormatter = (dollar: number) => {
     const strDollar = `${dollar}`;
     const arr = [];
@@ -14,31 +29,34 @@ export default function SideInfo({ isTypeTV, detailData, keywordData }: any) {
     return `$${format}.00`;
   };
 
+  useEffect(() => {
+    if (isTypeTV) setContentsData(tvInfolData);
+    else setContentsData(movieInfolData);
+  }, [movieInfolData, tvInfolData]);
+
   return (
     <div className={sideInfoStyles.side_info}>
       <div>
         <strong>원제</strong>
-        <div>
-          {isTypeTV ? detailData.original_name : detailData.original_title}
-        </div>
+        <div>{tvInfolData.original_name || movieInfolData.original_title}</div>
       </div>
       <div>
         <strong>상태</strong>
-        <div>{detailData.status}</div>
+        <div>{contentsData.status}</div>
       </div>
       <div>
         <strong>원어</strong>
-        <div>{detailData.original_language}</div>
+        <div>{contentsData.original_language}</div>
       </div>
       {!isTypeTV && (
         <>
           <div>
             <strong>제작비</strong>
-            <div>{dollarFormatter(detailData.budget)}</div>
+            <div>{dollarFormatter(movieInfolData.budget)}</div>
           </div>
           <div>
             <strong>수익</strong>
-            <div>{dollarFormatter(detailData.revenue)}</div>
+            <div>{dollarFormatter(movieInfolData.revenue)}</div>
           </div>
         </>
       )}
@@ -46,23 +64,14 @@ export default function SideInfo({ isTypeTV, detailData, keywordData }: any) {
       <div>
         <h4>키워드</h4>
         <ul>
-          {isTypeTV
-            ? keywordData.results.map((val: any, idx: number) => {
-                return (
-                  <li key={`${val.name}${idx}`}>
-                    {/* <Link href="">{val.name}</Link> */}
-                    {val.name}
-                  </li>
-                );
-              })
-            : keywordData.keywords.map((val: any, idx: number) => {
-                return (
-                  <li key={`${val.name}${idx}`}>
-                    {/* <Link href="">{val.name}</Link> */}
-                    {val.name}
-                  </li>
-                );
-              })}
+          {keywordData.map((val: KeywordType, idx: number) => {
+            return (
+              <li key={`${val.name}${idx}`}>
+                {/* <Link href="">{val.name}</Link> */}
+                {val.name}
+              </li>
+            );
+          })}
         </ul>
       </div>
     </div>

--- a/components/pages/contentsDetail/topInfo.tsx
+++ b/components/pages/contentsDetail/topInfo.tsx
@@ -4,9 +4,28 @@ import CustomImage from "@/components/common/customImage";
 
 import topInfoStyles from "@styles/pages/contentsDetail/topInfo.module.scss";
 import VoteAverage from "@/components/common/voteAverage";
+import { useEffect, useState } from "react";
 
-export default function TopInfo({ isTypeTV, detailData, date }: any) {
+export default function TopInfo({
+  isTypeTV,
+  movieInfolData,
+  tvInfolData,
+  date,
+}: {
+  isTypeTV: boolean;
+  movieInfolData: MovieInfoType;
+  tvInfolData: TVShowInfoType;
+  date: {
+    year: string;
+    month: string;
+    day: string;
+  };
+}) {
   const bgDefaultUrl = "https://image.tmdb.org/t/p/w1920_and_h800_multi_faces/";
+
+  const [contentsData, setContentsData] = useState<
+    MovieInfoType | TVShowInfoType
+  >(movieInfolData || tvInfolData);
 
   const runtimeFormatter = (runtime: number) => {
     if (runtime < 60) return `${runtime}m`;
@@ -18,11 +37,16 @@ export default function TopInfo({ isTypeTV, detailData, date }: any) {
     return `${hour}h ${minute}m`;
   };
 
+  useEffect(() => {
+    if (isTypeTV) setContentsData(tvInfolData);
+    else setContentsData(movieInfolData);
+  }, [movieInfolData, tvInfolData]);
+
   return (
     <div
       className={topInfoStyles.top_info}
       style={{
-        backgroundImage: `url(${bgDefaultUrl}${detailData.backdrop_path})`,
+        backgroundImage: `url(${bgDefaultUrl}${contentsData.backdrop_path})`,
       }}
     >
       <div>
@@ -31,14 +55,14 @@ export default function TopInfo({ isTypeTV, detailData, date }: any) {
             <CustomImage
               className={topInfoStyles.poster_image}
               type="content"
-              src={`https://image.tmdb.org/t/p/w300_and_h450_bestv2/${detailData.poster_path}`}
+              src={`https://image.tmdb.org/t/p/w300_and_h450_bestv2/${contentsData.poster_path}`}
             />
             {/* <div className="ottOffer"></div> */}
           </div>
           <div className={topInfoStyles.info}>
             <div className={topInfoStyles.title_wrapper}>
               <div className={topInfoStyles.title}>
-                <span>{isTypeTV ? detailData.name : detailData.title}</span>{" "}
+                <span>{tvInfolData.name || movieInfolData.title}</span>{" "}
                 <span>({date.year})</span>
               </div>
               <div>
@@ -50,18 +74,25 @@ export default function TopInfo({ isTypeTV, detailData, date }: any) {
                   </span>
                 )}
                 <span>
-                  {detailData.genres.map((val: any, idx: number, arr: any) => {
-                    return (
-                      <Link key={`${val.name}${idx}`} href="">
-                        {val.name}
-                        {idx !== arr.length - 1 ? ", " : ""}
-                      </Link>
-                    );
-                  })}
+                  {contentsData.genres &&
+                    contentsData.genres.map(
+                      (
+                        val: GenreDataType,
+                        idx: number,
+                        arr: GenreDataType[]
+                      ) => {
+                        return (
+                          <Link key={`${val.name}${idx}`} href="">
+                            {val.name}
+                            {idx !== arr.length - 1 ? ", " : ""}
+                          </Link>
+                        );
+                      }
+                    )}
                 </span>
                 {!isTypeTV && (
                   <span className={topInfoStyles.dot}>
-                    {runtimeFormatter(detailData.runtime)}
+                    {runtimeFormatter(movieInfolData.runtime)}
                   </span>
                 )}
               </div>
@@ -72,7 +103,7 @@ export default function TopInfo({ isTypeTV, detailData, date }: any) {
                 font={20}
                 top={0}
                 left={0}
-                vote={detailData.vote_average}
+                vote={contentsData.vote_average}
               />
               <div>
                 회원
@@ -86,23 +117,27 @@ export default function TopInfo({ isTypeTV, detailData, date }: any) {
               </button> */}
             </div>
             <div className={topInfoStyles.summary}>
-              <div className={topInfoStyles.tagline}>{detailData.tagline}</div>
+              <div className={topInfoStyles.tagline}>
+                {contentsData.tagline}
+              </div>
               <div>개요</div>
-              <div>{detailData.overview}</div>
+              <div>{contentsData.overview}</div>
             </div>
             <div className={topInfoStyles.producer}>
               <ul>
                 {isTypeTV &&
-                  detailData.created_by.map((val: any, idx: number) => {
-                    return (
-                      <li key={`${val.name}${idx}`}>
-                        <div>
-                          <Link href="">{val.name}</Link>
-                        </div>
-                        <div>창작자</div>
-                      </li>
-                    );
-                  })}
+                  tvInfolData.created_by.map(
+                    (val: CreatedByType, idx: number) => {
+                      return (
+                        <li key={`${val.name}${idx}`}>
+                          <div>
+                            <Link href="">{val.name}</Link>
+                          </div>
+                          <div>창작자</div>
+                        </li>
+                      );
+                    }
+                  )}
               </ul>
             </div>
           </div>

--- a/components/pages/home/categoryTab.tsx
+++ b/components/pages/home/categoryTab.tsx
@@ -12,7 +12,7 @@ export default function CategoryTab({
 }: {
   tabData: TabData[];
   currentTab: string;
-  onClick: any;
+  onClick: (type: string) => void;
 }) {
   return (
     <div className={categoryTabStyles.category_tab}>

--- a/components/pages/home/freeWatchList.tsx
+++ b/components/pages/home/freeWatchList.tsx
@@ -3,18 +3,17 @@ import { useEffect, useRef, useState } from "react";
 import { apiClient } from "@/api/httpClient";
 import HomeFilterBar from "./categoryTab";
 import HomeList from "./homeList";
-import { ContentDataType } from "@/components/pages/contents/contents";
 
 import contentsStyles from "@styles/pages/home/contents.module.scss";
 
-export default function FreeWatchList({ list }: any) {
+export default function FreeWatchList({ list }: { list: ContentsDataType[] }) {
   const listRef = useRef<HTMLUListElement>(null);
   const commonQuery =
     "language=ko&watch_region=KR&sort_by=popularity.desc&with_watch_monetization_types=free|ads&with_genres=&vote_average.gte=0&vote_average.lte=10&vote_count.gte=0&with_runtime.gte=0&with_runtime.lte=400&page=1";
   const movieQuery = `discover/movie?include_adult=false&include_video=false&${commonQuery}`;
   const tvQuery = `discover/tv?include_adult=false&include_null_first_air_dates=false&${commonQuery}`;
 
-  const [listData, setListData] = useState<ContentDataType[]>([]);
+  const [listData, setListData] = useState<ContentsDataType[]>([]);
   const [currentTab, setCurrentTab] = useState<string>("movie");
 
   const tabData = [

--- a/components/pages/home/homeList.tsx
+++ b/components/pages/home/homeList.tsx
@@ -3,7 +3,6 @@ import Link from "next/link";
 import homeListStyles from "@styles/pages/home/homeList.module.scss";
 
 import { dateFormatter } from "@/utils/dateFormatter";
-import { ContentDataType } from "@/components/pages/contents/contents";
 import { RefObject } from "react";
 import CustomImage from "@/components/common/customImage";
 
@@ -13,12 +12,12 @@ export default function HomeList({
   listData,
   listRef,
 }: {
-  listData: ContentDataType[];
+  listData: ContentsDataType[];
   listRef: RefObject<HTMLUListElement>;
 }) {
   return (
     <ul ref={listRef} className={homeListStyles.home_list}>
-      {listData.map((val: ContentDataType) => {
+      {listData.map((val: ContentsDataType) => {
         const { id, poster_path, vote_average } = val;
 
         const date = val.first_air_date || val.release_date;

--- a/components/pages/home/popularList.tsx
+++ b/components/pages/home/popularList.tsx
@@ -7,7 +7,7 @@ import { ContentDataType } from "@/components/pages/contents/contents";
 
 import contentsStyles from "@styles/pages/home/contents.module.scss";
 
-export default function PopularList({ list }: any) {
+export default function PopularList({ list }: { list: ContentsDataType[] }) {
   const listRef = useRef<HTMLUListElement>(null);
 
   const [listData, setListData] = useState<ContentDataType[]>([]);
@@ -20,24 +20,25 @@ export default function PopularList({ list }: any) {
     { name: "극장", type: "theater" },
   ];
 
-  const dataRandomSort = (response: any) => {
-    if (response.length > 1) {
-      const [movieStream, tvStream] = response;
-      const movieData = movieStream.data.results;
-      const tvData = tvStream.data.results;
-      const concat = movieData.concat(tvData);
-
-      return concat.sort(() => Math.random() - 0.5);
-    } else return response[0].data.results.sort(() => Math.random() - 0.5);
+  const dataRandomSort = (data: ContentsDataType[]) => {
+    return data.sort(() => Math.random() - 0.5);
   };
 
   const onClickTab = (type: string) => {
     setCurrentTab(type);
 
     popularListApi(type).then((res) => {
-      const data = dataRandomSort(res);
+      let sortData = [];
 
-      setListData(data);
+      if (res.length > 1) {
+        const [movieStream, tvStream] = res;
+        const movieData = movieStream.data.results;
+        const tvData = tvStream.data.results;
+        const concat = movieData.concat(tvData);
+        sortData = dataRandomSort(concat);
+      } else sortData = dataRandomSort(res[0].data.results);
+
+      setListData(sortData);
 
       if (listRef.current) listRef.current.scrollLeft = 0;
     });

--- a/components/pages/home/popularList.tsx
+++ b/components/pages/home/popularList.tsx
@@ -3,14 +3,13 @@ import { useEffect, useRef, useState } from "react";
 import { popularListApi } from "@/api/httpClient";
 import HomeFilterBar from "./categoryTab";
 import HomeList from "./homeList";
-import { ContentDataType } from "@/components/pages/contents/contents";
 
 import contentsStyles from "@styles/pages/home/contents.module.scss";
 
 export default function PopularList({ list }: { list: ContentsDataType[] }) {
   const listRef = useRef<HTMLUListElement>(null);
 
-  const [listData, setListData] = useState<ContentDataType[]>([]);
+  const [listData, setListData] = useState<ContentsDataType[]>([]);
   const [currentTab, setCurrentTab] = useState<string>("stream");
 
   const tabData = [

--- a/components/pages/home/trendingList.tsx
+++ b/components/pages/home/trendingList.tsx
@@ -3,14 +3,13 @@ import { useEffect, useRef, useState } from "react";
 import { apiClient } from "@/api/httpClient";
 import HomeFilterBar from "./categoryTab";
 import HomeList from "./homeList";
-import { ContentDataType } from "@/components/pages/contents/contents";
 
 import contentsStyles from "@styles/pages/home/contents.module.scss";
 
-export default function TrendingList({ list }: any) {
+export default function TrendingList({ list }: { list: ContentsDataType[] }) {
   const listRef = useRef<HTMLUListElement>(null);
 
-  const [listData, setListData] = useState<ContentDataType[]>([]);
+  const [listData, setListData] = useState<ContentsDataType[]>([]);
   const [currentTab, setCurrentTab] = useState<string>("day");
 
   const tabData = [

--- a/components/pages/personDetail/career.tsx
+++ b/components/pages/personDetail/career.tsx
@@ -2,13 +2,13 @@ import Link from "next/link";
 
 import careerStyles from "@styles/pages/personDetail/career.module.scss";
 
-export default function Career({ acting }: any) {
+export default function Career({ acting }: { acting: PersonDetailDataType[] }) {
   return (
     <ul className={careerStyles.career}>
-      {acting.map((val: any) => {
+      {acting.map((val: PersonDetailDataType) => {
         const { id, media_type } = val;
         const title = val.title || val.name;
-        const date: string = val.first_air_date || val.release_date;
+        const date = val.first_air_date || val.release_date;
         const year = date ? date.substring(0, 4) : "—";
 
         return (

--- a/components/pages/personDetail/career.tsx
+++ b/components/pages/personDetail/career.tsx
@@ -5,14 +5,17 @@ import careerStyles from "@styles/pages/personDetail/career.module.scss";
 export default function Career({ acting }: { acting: PersonDetailDataType[] }) {
   return (
     <ul className={careerStyles.career}>
-      {acting.map((val: PersonDetailDataType) => {
+      {acting.map((val: PersonDetailDataType, idx: number) => {
         const { id, media_type } = val;
         const title = val.title || val.name;
         const date = val.first_air_date || val.release_date;
         const year = date ? date.substring(0, 4) : "—";
 
         return (
-          <li key={id} className={val.topLine ? careerStyles.top_line : ""}>
+          <li
+            key={`${id}${idx}`}
+            className={val.topLine ? careerStyles.top_line : ""}
+          >
             <div className={careerStyles.career_year}>{year}</div>
             <div className={careerStyles.dot}>
               <div></div>

--- a/components/pages/personDetail/famous.tsx
+++ b/components/pages/personDetail/famous.tsx
@@ -4,11 +4,15 @@ import CustomImage from "@/components/common/customImage";
 
 import famousStyles from "@styles/pages/personDetail/famous.module.scss";
 
-export default function Famous({ famousData }: any) {
+export default function Famous({
+  famousData,
+}: {
+  famousData: PersonDetailDataType[];
+}) {
   return (
     <div className={famousStyles.famous}>
       <ul>
-        {famousData.map((val: any, idx: number) => {
+        {famousData.map((val: PersonDetailDataType) => {
           const { id, media_type } = val;
           const title = val.title || val.name;
           return (

--- a/components/pages/personDetail/history.tsx
+++ b/components/pages/personDetail/history.tsx
@@ -1,6 +1,12 @@
 import historyStyles from "@styles/pages/personDetail/history.module.scss";
 
-export default function History({ biography, personDetailData }: any) {
+export default function History({
+  biography,
+  personInfoData,
+}: {
+  biography: string[];
+  personInfoData: personInfoType;
+}) {
   return (
     <div className={historyStyles.history}>
       <div className={historyStyles.history_text}>
@@ -8,7 +14,7 @@ export default function History({ biography, personDetailData }: any) {
           ? biography.map((val: string, idx: number) => {
               return <div key={`${biography}${idx}`}>{val}</div>;
             })
-          : `${personDetailData.name}의 약력 란이 비어있습니다.`}
+          : `${personInfoData.name}의 약력 란이 비어있습니다.`}
       </div>
     </div>
   );

--- a/components/pages/personDetail/sideInfo.tsx
+++ b/components/pages/personDetail/sideInfo.tsx
@@ -2,7 +2,15 @@ import CustomImage from "@/components/common/customImage";
 
 import sideInfoStyles from "@styles/pages/personDetail/sideInfo.module.scss";
 
-export default function SideInfo({ gender, acting, personDetailData }: any) {
+export default function SideInfo({
+  acting,
+  personInfoData,
+}: {
+  acting: PersonDetailDataType[];
+  personInfoData: personInfoType;
+}) {
+  const gender = ["-", "여성", "남성"];
+
   const yearsCalc = (birth: string) => {
     if (!birth) return;
 
@@ -17,14 +25,14 @@ export default function SideInfo({ gender, acting, personDetailData }: any) {
       <CustomImage
         className={sideInfoStyles.person_image}
         type="person"
-        src={`https://image.tmdb.org/t/p/w300_and_h450_bestv2/${personDetailData.profile_path}`}
+        src={`https://image.tmdb.org/t/p/w300_and_h450_bestv2/${personInfoData.profile_path}`}
       />
       <div className={sideInfoStyles.info}>
         <div>인물 정보</div>
         <div className={sideInfoStyles.intro}>
           <div>
             <p>유명 분야</p>
-            <div>{personDetailData.known_for_department}</div>
+            <div>{personInfoData.known_for_department}</div>
           </div>
           <div>
             <p>참여 작품 수</p>
@@ -32,35 +40,35 @@ export default function SideInfo({ gender, acting, personDetailData }: any) {
           </div>
           <div>
             <p>성별</p>
-            <div>{gender[personDetailData.gender]}</div>
+            <div>{gender[personInfoData.gender]}</div>
           </div>
           <div>
             <p>생일</p>
             <div>
-              {personDetailData.birthday || "-"}
-              {!personDetailData.deathday
-                ? yearsCalc(personDetailData.birthday)
+              {personInfoData.birthday || "-"}
+              {!personInfoData.deathday
+                ? yearsCalc(personInfoData.birthday)
                 : ""}
             </div>
           </div>
-          {personDetailData.deathday && (
+          {personInfoData.deathday && (
             <div>
               <p>사망일</p>
               <div>
-                {personDetailData.deathday}
-                {yearsCalc(personDetailData.birthday)}
+                {personInfoData.deathday}
+                {yearsCalc(personInfoData.birthday)}
               </div>
             </div>
           )}
           <div>
             <p>출생지</p>
-            <div>{personDetailData.place_of_birth || "-"}</div>
+            <div>{personInfoData.place_of_birth || "-"}</div>
           </div>
           <div>
             <p>다른 명칭</p>
             <ul>
-              {personDetailData.also_known_as.length > 0
-                ? personDetailData.also_known_as.map((val: string) => {
+              {personInfoData.also_known_as.length > 0
+                ? personInfoData.also_known_as.map((val: string) => {
                     return <li key={val}>{val}</li>;
                   })
                 : "-"}

--- a/components/pages/searchResults/personList.tsx
+++ b/components/pages/searchResults/personList.tsx
@@ -1,6 +1,4 @@
 import Link from "next/link";
-import { PersonDataType } from "@/app/person/page";
-import { PersonDetailDataType } from "@/app/personDetail/page";
 import CustomImage from "@/components/common/customImage";
 
 import personListStyles from "@styles/pages/searchResults/personList.module.scss";

--- a/components/pages/searchResults/searchResultsList.tsx
+++ b/components/pages/searchResults/searchResultsList.tsx
@@ -1,7 +1,6 @@
 import Link from "next/link";
 
 import { dateFormatter } from "@/utils/dateFormatter";
-import { ContentDataType } from "@/components/pages/contents/contents";
 import CustomImage from "@/components/common/customImage";
 
 import searchResultsListStyles from "@styles/pages/searchResults/searchResultsList.module.scss";
@@ -11,11 +10,11 @@ export default function SearchResultsList({
   list,
 }: {
   type: string;
-  list: ContentDataType[];
+  list: ContentsDataType[];
 }) {
   return (
     <ul className={searchResultsListStyles.search_results_list}>
-      {list.map((val: ContentDataType) => {
+      {list.map((val: ContentsDataType) => {
         const { id, poster_path, overview } = val;
 
         const title = val.title || val.name;

--- a/datahandling/discoverQuery.ts
+++ b/datahandling/discoverQuery.ts
@@ -1,11 +1,3 @@
-import {
-  AirDateType,
-  AvailabilitiesType,
-  DiscoverDataType,
-  GenreDataType,
-  ReleaseDateType,
-} from "@/components/pages/contents/contents";
-
 const availabilitiesQuery = (data: AvailabilitiesType) => {
   if (data.all_availabilities) return "";
   let monetization = "";

--- a/types/api.d.ts
+++ b/types/api.d.ts
@@ -1,0 +1,150 @@
+interface ServerResponse<T> {
+  page: number;
+  results: T[];
+  total_pages: number;
+  total_results: number;
+}
+
+interface ContentsDataType {
+  adult: boolean;
+  backdrop_path?: string;
+  genre_ids: number[];
+  id: number;
+  original_language?: string;
+  original_title?: string;
+  overview?: string;
+  popularity?: number;
+  poster_path?: string;
+  release_date?: string;
+  first_air_date?: string;
+  title?: string;
+  name?: string;
+  video: boolean;
+  vote_average?: number;
+  vote_count?: number;
+}
+
+interface CastInfoType {
+  adult: boolean;
+  cast_id: number;
+  roles?: {
+    character: string;
+    credit_id: string;
+    episode_count: number;
+  }[];
+  character: string;
+  credit_id: string;
+  gender: number;
+  id: number;
+  known_for_department: string;
+  name: string;
+  order: number;
+  original_name: string;
+  popularity: number;
+  profile_path: string | null;
+}
+
+interface EpisodeToAirType {
+  air_date: string;
+  episode_number: number;
+  episode_type: string;
+  id: number;
+  name: string;
+  overview: string;
+  production_code: string;
+  runtime: number;
+  season_number: number;
+  show_id: number;
+  still_path: string;
+  vote_average: number;
+  vote_count: number;
+}
+
+interface ContentsInfoType {
+  adult: boolean;
+  backdrop_path: string;
+  genres: GenreDataType[];
+  homepage: string;
+  id: number;
+  production_companies: {
+    id: number;
+    logo_path?: string;
+    name?: string;
+    origin_country: string;
+  }[];
+  production_countries: {
+    iso_3166_1: string;
+    name: string;
+  }[];
+  spoken_languages: { english_name: string; iso_639_1: string; name: string }[];
+  overview: string;
+  popularity: number;
+  poster_path: string;
+  vote_average: number;
+  vote_count: number;
+}
+
+interface CreatedByType {
+  credit_id: string;
+  gender: number;
+  id: number;
+  name: string;
+  profile_path?: string;
+}
+
+interface TVShowInfoType extends ContentsInfoType {
+  created_by: CreatedByType[];
+  episode_run_time: number[];
+  first_air_date: string;
+
+  in_production: boolean;
+  languages: string[];
+  last_air_date: string;
+  last_episode_to_air: EpisodeToAirType;
+  name: string;
+  networks: {
+    id: number;
+    logo_path?: string;
+    name: string;
+    origin_country: string;
+  }[];
+  next_episode_to_air: null | EpisodeToAirType;
+  number_of_episodes: number;
+  number_of_seasons: number;
+  origin_country: string[];
+  original_language: string;
+  original_name: string;
+
+  seasons: {
+    air_date: string;
+    episode_count: number;
+    id: number;
+    name: string;
+    overview: string;
+    poster_path: string;
+    season_number: number;
+    vote_average: number;
+  }[];
+
+  status: string;
+  tagline: string;
+  type: string;
+}
+
+interface MovieInfoType extends ContentsInfoType {
+  belongs_to_collection: null | any;
+  budget: number;
+
+  imdb_id: string;
+  original_language: string;
+  original_title: string;
+
+  release_date: string;
+  revenue: number;
+  runtime: number;
+
+  status: string;
+  tagline: string;
+  title: string;
+  video: boolean;
+}

--- a/types/contents.d.ts
+++ b/types/contents.d.ts
@@ -1,0 +1,44 @@
+interface GenreDataType {
+  id: number;
+  name: string;
+  checked?: boolean;
+}
+
+interface ReleaseDateType {
+  [index: string]: boolean;
+  all_releases: boolean;
+  theater_limited: boolean;
+  theater: boolean;
+  premier: boolean;
+  digital: boolean;
+  physical_media: boolean;
+  tv: boolean;
+}
+
+interface AirDateType {
+  [index: string]: boolean;
+  all_episodes: true;
+  first_air_date: true;
+}
+
+interface AvailabilitiesType {
+  [index: string]: boolean;
+  all_availabilities: boolean;
+  stream: boolean;
+  free: boolean;
+  ads: boolean;
+  rent: boolean;
+  buy: boolean;
+}
+
+interface DiscoverDataType {
+  sort_by: string;
+  availabilities: AvailabilitiesType;
+  release: ReleaseDateType | AirDateType;
+  release_date_g: Date | null;
+  release_date_l: Date | null;
+  genre: GenreDataType[];
+  vote_average: number[];
+  vote_count: 0;
+  runtime: number[];
+}

--- a/types/contentsDetail.d.ts
+++ b/types/contentsDetail.d.ts
@@ -1,0 +1,10 @@
+interface KeywordType {
+  id: number;
+  name: string;
+}
+
+interface KeywordDataType {
+  id: number;
+  keywords?: KeywordType[];
+  results?: KeywordType[];
+}

--- a/types/person.d.ts
+++ b/types/person.d.ts
@@ -1,0 +1,11 @@
+interface PersonDataType {
+  adult: boolean;
+  gender: number;
+  id: number;
+  known_for: PersonDetailDataType[];
+  known_for_department?: string;
+  name?: string;
+  original_name?: string;
+  popularity?: number;
+  profile_path?: string;
+}

--- a/types/personDetail.d.ts
+++ b/types/personDetail.d.ts
@@ -1,0 +1,44 @@
+interface personInfoType {
+  adult: boolean;
+  also_known_as: string[];
+  biography: string;
+  birthday: string;
+  combined_credits: {
+    cast: any[];
+    crew: any[];
+  };
+  deathday: string | null;
+  gender: number;
+  homepage: string | null;
+  id: number;
+  imdb_id: string;
+  known_for_department: string;
+  name: string;
+  place_of_birth: string;
+  popularity: number;
+  profile_path: string | null;
+}
+
+interface PersonDetailDataType {
+  adult: boolean;
+  backdrop_path?: string;
+  character?: string;
+  credit_id?: string;
+  episode_count?: number;
+  first_air_date?: string;
+  release_date?: string;
+  genre_ids: number[];
+  id: number;
+  media_type?: string;
+  title?: string;
+  name?: string;
+  origin_country: string[];
+  original_language?: string;
+  original_name?: string;
+  overview?: string;
+  popularity?: number;
+  poster_path?: string;
+  vote_average?: number;
+  vote_count: number;
+  topLine?: boolean;
+}

--- a/types/searchResults.d.ts
+++ b/types/searchResults.d.ts
@@ -1,0 +1,21 @@
+type ConnetType = {
+  [index: string]: string;
+  tv: string;
+  movie: string;
+  person: string;
+  collection: string;
+  company: string;
+  keyword: string;
+};
+
+type SearchResultsDataType = {
+  page: number;
+  results: [];
+  total_pages: number;
+  total_results: number;
+};
+
+type SearchResultsResType = {
+  data: SearchResultsDataType;
+  type: string;
+};


### PR DESCRIPTION
## 타입 지정
- any로 지정된 타입 전체 페이지에 적합한 타입으로 지정
- 현재 10개 미만으로 any타입이 선언 되었으며 추후 바꿀 예정
## Fix
- [[personDetail] career 컴포넌트 id 충돌 이슈](https://github.com/ggj102/Tvie/commit/8903c113c61767e6a7f783b43c764be943ca447d)
- [[contents] filterBar 항목 오반영](https://github.com/ggj102/Tvie/commit/f17ff87b31e8ff9d7f8cd4418e1811485433508c)
- [forwardRef 사용 권장 warning](https://github.com/ggj102/Tvie/commit/813f3975e2dd1b5bd29aeee1dc8d0d097fbed73a)