### PR TITLE
History 페이지 추가

### DIFF
--- a/app/contentsDetail/components/contentsDetail.tsx
+++ b/app/contentsDetail/components/contentsDetail.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useEffect } from "react";
+import { useSearchParams } from "next/navigation";
+
+import addHistory from "@/utils/addHistory";
+
+export default function ContentsDetail({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const type = searchParams.get("type");
+    const id = searchParams.get("id");
+    addHistory(type, id);
+  }, []);
+
+  return <div>{children}</div>;
+}

--- a/app/contentsDetail/page.tsx
+++ b/app/contentsDetail/page.tsx
@@ -1,11 +1,12 @@
 import { contentsDetailApi } from "@/lib/api/httpClient";
+import { getManagementUser } from "@/lib/api/authZero";
 
+import ContentsDetail from "./components/contentsDetail";
 import TopInfo from "@/app/contentsDetail/components/topInfo";
 import MainCast from "@/app/contentsDetail/components/mainCast";
 import SideInfo from "@/app/contentsDetail/components/sideInfo";
 
 import contentsDetailStyles from "@styles/pages/contentsDetail/contentsDetail.module.scss";
-import { getManagementUser } from "@/lib/api/authZero";
 
 async function ServerSideProps(searchParams: any) {
   const { id, type } = searchParams;
@@ -65,7 +66,7 @@ export default async function ContentsDetailPage({ searchParams }: any) {
   } = await ServerSideProps(searchParams);
 
   return (
-    <>
+    <ContentsDetail>
       <TopInfo
         isSession={isSession}
         isFavorites={isFavorites}
@@ -82,6 +83,6 @@ export default async function ContentsDetailPage({ searchParams }: any) {
           keywordData={keywordData}
         />
       </div>
-    </>
+    </ContentsDetail>
   );
 }

--- a/app/history/components/historyList.tsx
+++ b/app/history/components/historyList.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import Link from "next/link";
+
+import { dateFormatter } from "@/utils/dateFormatter";
+
+import useHistoryList from "./useHistoryList";
+
+import CustomImage from "@/components/customImage";
+import VoteAverage from "@/components/voteAverage";
+import FavoritesButton from "@/components/favoritesButton";
+import Loading from "@/components/loading";
+
+import historyStyles from "@styles/pages/history/history.module.scss";
+
+export default function HistoryList({ isSession }: { isSession: boolean }) {
+  const { isLoading, listData, onClickEmptyList } = useHistoryList();
+
+  return isLoading ? (
+    <Loading />
+  ) : (
+    <div className={historyStyles.history_list}>
+      {listData.length > 0 ? (
+        <>
+          <div className={historyStyles.empty_button}>
+            <button onClick={onClickEmptyList}>목록 비우기</button>
+          </div>
+          <ul>
+            {listData.map((val: any) => {
+              const { type, id, vote_average, isFavorites } = val;
+
+              const title = val.title || val.name;
+              const imagePath = val.profile_path || val.poster_path;
+              const imageSize =
+                type === "person" ? "w235_and_h235" : "w220_and_h330";
+              const date = val.release_date || val.first_air_date;
+              const dateFormat = dateFormatter(date);
+              const link =
+                type === "person"
+                  ? `personDetail?id=${id}`
+                  : `contentsDetail?type=${type}&id=${id}`;
+
+              return (
+                <li key={id}>
+                  <Link href={`/${link}`}>
+                    <CustomImage
+                      className={historyStyles.image}
+                      type={type}
+                      src={`https://image.tmdb.org/t/p/${imageSize}_face/${imagePath}`}
+                    />
+                  </Link>
+                  {isSession ? (
+                    <div className={historyStyles.favorites_area}>
+                      <FavoritesButton
+                        isFavorites={isFavorites}
+                        id={id}
+                        type={type}
+                        size={24}
+                      />
+                    </div>
+                  ) : (
+                    <div className={historyStyles.empty_box}></div>
+                  )}
+
+                  {type === "person" ? (
+                    <div className={historyStyles.person_info}>
+                      <Link
+                        href={`/personDetail?id=${id}`}
+                        className={historyStyles.person_name}
+                      >
+                        {title}
+                      </Link>
+                    </div>
+                  ) : (
+                    <>
+                      <VoteAverage
+                        size={34}
+                        top={256}
+                        left={8}
+                        vote={vote_average}
+                      />
+                      <div className={historyStyles.title_release}>
+                        <Link href={`/${link}`} className={historyStyles.title}>
+                          {title}
+                        </Link>
+                        <div className={historyStyles.release}>
+                          {dateFormat}
+                        </div>
+                      </div>
+                    </>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        </>
+      ) : (
+        <div className={historyStyles.empty_text}>
+          최근에 본 컨텐츠 및 인물이 없습니다.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/history/components/useHistoryList.ts
+++ b/app/history/components/useHistoryList.ts
@@ -1,0 +1,69 @@
+"use client";
+import { useEffect, useState } from "react";
+import axios from "axios";
+
+import { apiClient } from "@/lib/api/httpClient";
+import { favoitesList } from "@/lib/api/authZero";
+
+export default function useHistoryList() {
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [listData, setListData] = useState<any>([]);
+
+  const onClickEmptyList = () => {
+    const isConfirmed = confirm(`목록이 전부 삭제 됩니다.\n진행 하시겠습니까?`);
+
+    if (isConfirmed) {
+      localStorage.removeItem("historyData");
+      setListData([]);
+    }
+  };
+
+  useEffect(() => {
+    if (listData.length > 0) return;
+
+    const historyData = localStorage.getItem("historyData");
+    if (!historyData) {
+      setIsLoading(false);
+      return;
+    }
+
+    const getData = JSON.parse(historyData);
+
+    const requests = getData.map((val: any) => {
+      const query =
+        val.type === "person"
+          ? "append_to_response=combined_credits&language=ko"
+          : "language=ko";
+
+      const path = `${val.type}/${val.id}?${query}`;
+
+      return apiClient
+        .get(path)
+        .then((res) => {
+          return { ...res.data, type: val.type };
+        })
+        .catch((error) => {
+          throw error;
+        });
+    });
+
+    Promise.all(requests)
+      .then(async (res) => {
+        axios.get("/api/users/favorites").then((user) => {
+          if (user.data === "Unauthorized") {
+            setListData(res);
+          } else {
+            const addData = favoitesList(user.data, res);
+            setListData(addData);
+          }
+
+          setIsLoading(false);
+        });
+      })
+      .catch((error) => {
+        throw error;
+      });
+  }, [listData]);
+
+  return { isLoading, listData, onClickEmptyList };
+}

--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -1,0 +1,22 @@
+import { getSession } from "@auth0/nextjs-auth0";
+
+import HistoryList from "./components/historyList";
+
+import historyStyles from "@styles/pages/history/history.module.scss";
+
+async function ServerSideProps() {
+  const isSession = await getSession();
+
+  return { isSession: !!isSession?.user };
+}
+
+export default async function HistoryPage() {
+  const { isSession } = await ServerSideProps();
+
+  return (
+    <div className={historyStyles.history_container}>
+      <div className={historyStyles.history_title}>히스토리</div>
+      <HistoryList isSession={isSession} />
+    </div>
+  );
+}

--- a/app/personDetail/components/historyInfo/useHistoryInfo.ts
+++ b/app/personDetail/components/historyInfo/useHistoryInfo.ts
@@ -1,7 +1,11 @@
 import { useEffect, useRef, useState } from "react";
+import { useSearchParams } from "next/navigation";
+
+import addHistory from "@/utils/addHistory";
 
 export default function useHistoryInfo() {
   const textRef = useRef<any>(null);
+  const searchParams = useSearchParams();
 
   const [isOpenHistory, setIsOpenHistory] = useState<boolean>(false);
   const [isOpenBtn, setIsOpenBtn] = useState<boolean>(false);
@@ -14,6 +18,10 @@ export default function useHistoryInfo() {
   };
 
   useEffect(() => {
+    const paramsId = searchParams.get("id");
+
+    addHistory("person", paramsId);
+
     if (textRef) {
       if (textRef.current.offsetHeight > 222) setIsOpenBtn(true);
     }

--- a/components/navigation/index.tsx
+++ b/components/navigation/index.tsx
@@ -30,6 +30,7 @@ export default function Navigation({ isSession }: { isSession: boolean }) {
           <NavItem href="/contents/movie" title="Movie" />
           <NavItem href="/contents/tv" title="TV" />
           <NavItem href="/person" title="Person" />
+          <NavItem href="/history" title="히스토리" />
           {isSession && <NavItem href="/favorites" title="즐겨찾기" />}
         </div>
         <div className={navigationStyles.flex}>

--- a/styles/pages/history/history.module.scss
+++ b/styles/pages/history/history.module.scss
@@ -1,0 +1,113 @@
+.history_container {
+  width: 1300px;
+  min-height: calc(100vh - 328px);
+
+  margin: 0 auto;
+}
+
+.history_title {
+  margin-top: 30px;
+  margin-bottom: 20px;
+
+  font-size: 1.6em;
+  font-weight: bold;
+}
+
+.history_list {
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  border: 1px solid rgba(227, 227, 227, 1);
+  border-radius: 8px;
+  box-sizing: border-box;
+  padding: 20px;
+
+  margin-bottom: 60px;
+
+  .empty_button {
+    width: 100%;
+    display: flex;
+    justify-content: end;
+    margin-bottom: 20px;
+
+    gap: 10px;
+  }
+
+  ul {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 30px;
+
+    & > div {
+      color: gray;
+    }
+  }
+
+  li {
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    overflow: hidden;
+    border-radius: 8px;
+
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    border: 1px solid rgba(227, 227, 227, 1);
+    box-sizing: border-box;
+  }
+
+  .image {
+    position: relative;
+    overflow: hidden;
+    width: 100%;
+    height: 273px;
+    max-height: calc((1300px - 140px) / 4);
+    margin: 0;
+  }
+
+  .empty_text {
+    width: 100%;
+
+    color: gray;
+  }
+}
+
+.favorites_area {
+  width: 100%;
+  display: flex;
+  justify-content: end;
+
+  padding: 5px 10px;
+  box-sizing: border-box;
+}
+
+.empty_box {
+  width: 100%;
+  height: 26px;
+}
+
+.title_release {
+  padding: 0 10px;
+
+  .title {
+    font-weight: bold;
+
+    &:hover {
+      color: var(--main_blue);
+    }
+  }
+  .release {
+    margin-top: 4px;
+    font-size: 14px;
+    color: rgba(0, 0, 0, 0.6);
+  }
+}
+
+.person_info {
+  padding: 0 10px;
+  width: 100%;
+  box-sizing: border-box;
+
+  .person_name {
+    width: 100%;
+    line-height: 1.2em;
+    font-weight: bold;
+  }
+}

--- a/utils/addHistory.ts
+++ b/utils/addHistory.ts
@@ -1,0 +1,25 @@
+export default function addHistory(type: any, id: any) {
+  const historyData = localStorage.getItem("historyData");
+  const addData = { type, id };
+
+  if (!historyData) {
+    const data = [addData];
+    localStorage.setItem("historyData", JSON.stringify(data));
+  } else {
+    const getData = JSON.parse(historyData);
+    let copyData = [...getData];
+
+    const findIndex = getData.findIndex(
+      (val: any) => val.type === addData.type && val.id === addData.id
+    );
+
+    if (findIndex != -1) {
+      const splice = [...getData];
+      splice.splice(findIndex, 1);
+      copyData = [...splice];
+    }
+
+    copyData.unshift(addData);
+    localStorage.setItem("historyData", JSON.stringify(copyData));
+  }
+}


### PR DESCRIPTION
## History Page
- 페이지 특징
  - 히스토리 페이지는 모든 사용자가 사용할 수 있는 페이지이다.
  - 상세 페이지 진입 시 목록에 추가 된다. (ContentsDetail, PersonDetail)
  - 최근 본 목록은 사용자에게 중요도가 낮은 목록이므로 개별 삭제 기능은 존재하지 않는다.
  - 최근 본 목록에서도 세션이 있는 상태라면 즐겨찾기 기능도 이용할 수 있다.
  - 중복 일 경우 기존 데이터는 삭제하고 앞에 추가
  - 목록 비우기를 통해 모든 목록을 리셋한다.

- 데이터 관리 방식
  - 로컬스토리지를 사용하여 데이터 보관